### PR TITLE
bump setup-ruby version in deploy action

### DIFF
--- a/.github/workflows/deploy-to-pages.yaml
+++ b/.github/workflows/deploy-to-pages.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.0
       - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # v1.204.0
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Build middleman site


### PR DESCRIPTION
Same fix as 27f5c940fec4e97283d132ba8c44cc5f92f0a649 but for the deploy action which is also [failing](https://github.com/communitiesuk/mhclg-way/actions/runs/12352556066/job/34469950404). (Hopefully this fixes it but difficult to test until merge)