### PR TITLE
Remove warning to avoid commenting on pull-requests outside of working hours

### DIFF
--- a/source/standards/pull-requests.html.md.erb
+++ b/source/standards/pull-requests.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Pull requests
-last_reviewed_on: 2000-01-01
+last_reviewed_on: 2024-12-16
 review_in: 12 months
 ---
 # <%= current_page.data.title %>


### PR DESCRIPTION
This was discussed in MHCLG way workshop (6/12/24); our group considered this guidance too prescriptive.

We did not agree that this would set an expectation that we support making changes at night or during the weekend and we acknowledged that there may be times when teams wish to submit/update a PR outside of working hours.
