### PR TITLE
Add MHCLG to copyright notice in licensing guidance

### DIFF
--- a/source/manuals/licensing.html.md.erb
+++ b/source/manuals/licensing.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Licensing
-last_reviewed_on: 2000-01-01
+last_reviewed_on: 2025-02-19
 review_in: 6 months
 ---
 
@@ -52,10 +52,10 @@ License", so that readers are quickly able to see what licence is being used.
 
 ### Copyright notice
 
-The Copyright is Crown Copyright; you can put "Government Digital Service" in
+The Copyright is Crown Copyright; you can put "Ministry of Housing, Communities & Local Government" in
 brackets.
 
-For example, `Copyright (c) <%= Time.current.year %> Crown Copyright (Government Digital Service)`.
+For example, `Copyright (c) <%= Time.current.year %> Crown Copyright (Ministry of Housing, Communities & Local Government)`.
 
 The year should be the year the code was first published. Where the code is
 continually updated with significant changes, you can show the year as a period
@@ -66,7 +66,7 @@ sheet][uk-fact-sheet].
 
 ### Example
 
-There is a good example of a licence in the [pay-adminusers][pay-licence] repo.
+There is a good example of a licence in the [mhclg-way][mhclg-way-licence] repo.
 
 ## Guidelines for repositories that are open documentation
 
@@ -81,7 +81,7 @@ The [MHCLG Way][mhclg-way] repo is a good example of licensing open documentatio
 
 [mit-license]: https://opensource.org/licenses/MIT
 [uk-fact-sheet]: https://copyrightservice.co.uk/copyright/p03_copyright_notices
-[pay-licence]: https://github.com/alphagov/pay-adminusers/blob/master/LICENCE
+[mhclg-way-licence]: https://github.com/communitiesuk/mhclg-way/blob/main/LICENCE
 [ogl-licence]: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
 [mhclg-way]: https://github.com/communitiesuk/mhclg-way
 [gh-licence-guidance]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository#including-an-open-source-license-in-your-repository


### PR DESCRIPTION
Removed reference to GDS and replaced with MHCLG.