### PR TITLE
Linking to gov.uk design system from html style guides

### DIFF
--- a/source/manuals/programming-languages/html.html.md.erb
+++ b/source/manuals/programming-languages/html.html.md.erb
@@ -1,11 +1,14 @@
 ---
 title: HTML coding style
-last_reviewed_on: 2024-09-02
+last_reviewed_on: 2025-07-09
 review_in: 12 months
 owner_slack: '#mhclg-way'
 ---
 
 # <%= current_page.data.title %>
+
+## GOV.UK Design System
+The [GOV.UK design system][] is recommended for all html pages and a [basic page template] is provided as a starting point.
 
 ## Browser support
 
@@ -32,65 +35,6 @@ whether to omit values from attributes that do not need them or whether to add
 trailing slashes to void elements. However, the approach you adopt should be
 consistent throughout your code.
 
-### Header
-
-`<header role="banner">` should be used to contain your home link, branding, search,
-and any global navigation you may have.
-
-### Main content
-
-`<main role="main">` should be used to identify the main content of your page.
-
-A "Skip to main content" link should be added to help screen reader and keyboard
-users skip past your general site navigation and get straight to the content.
-You can use the [skip link component from the GOV.UK Design System](https://design-system.service.gov.uk/components/skip-link/)
-for this.
-
-### Navigational elements
-
-Use `<nav role="navigation">` to wrap groups of links that are not already in
-another context (for example, `<footer>`). Common examples of navigation sections are
-menus, tables of contents, and indexes.
-
-If you use more than one `<nav>` block in your page it is advisable to give
-each one an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/) using
-[aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
-or
-[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label),
-to make clear the type of navigation contained by each.
-
-The GOV.UK blog has [more information regarding the use of the `<nav>` tag](https://insidegovuk.blog.gov.uk/2013/07/03/rethinking-navigation/).
-
-### Aside
-
-`<aside role="complementary">` should be used for content related to the primary content
-of the webpage, but which does not constitute the primary content of the page.
-
-Examples include author information, related links and related content.
-
-### Footer
-
-`<footer role="contentinfo">` should be used for the footer of the site.
-
-### Region landmarks
-
-Use region landmarks to surface important areas of a page where it's not
-appropriate to use any of the other types of landmarks.
-
-You can create region landmarks by using the `<section>` tag. The `<section>` must
-have an [accessible name](https://www.tpgi.com/what-is-an-accessible-name/), which can be provided using the
-[aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
-or
-[aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
-attributes. [A `<section>` tag without an accessible name is semantically the same
-as a `<div>` tag](https://w3c.github.io/html-aam/#el-section).
-
-Region landmarks should only be used where users will likely want to be able to
-navigate to the grouping easily and to have it listed in a summary of the page.
-
-You can already use headings and the other landmarks to identify sections of
-the page. Region landmarks should be used only when those are proven not to
-work well enough and doing so saves users more effort than it adds.
 
 ## Individual element guidance
 
@@ -107,7 +51,7 @@ Italics should be avoided according to the [GOV.UK content style guide](https://
 Bold can be used sparingly, but can make large blocks of text difficult to read.
 
 Semantically, words voiced with emphasis can be marked up with `<em>`, whereas
-words conveying a sense or urgency or warning should be marked up with
+words conveying a sense of urgency or warning should be marked up with
 `<strong>`. In theory screen readers could adopt a different tone of voice for
 this markup, though none of the major ones currently do.
 
@@ -145,3 +89,6 @@ or the classes `govuk-visually-hidden` and `govuk-visually-hidden-focusable`.
 
 Visually hidden text is often a sign that something can be simplified or made visible to
 benefit sighted users too, so should be used sparingly.
+
+[GOV.UK design system]: https://design-system.service.gov.uk/get-started/
+[basic page template]: https://design-system.service.gov.uk/styles/page-template/


### PR DESCRIPTION
As per ticket on mural board, removes some specific html guidance and directs users to the gov.uk design system getting started page.