### PR TITLE
Update emails page

### DIFF
--- a/source/partials/_nav-operating-a-service.html.erb
+++ b/source/partials/_nav-operating-a-service.html.erb
@@ -5,7 +5,7 @@
   <li><a href="/standards/storing-credentials.html">How to store credentials</a></li>
   <li><a href="/standards/how-to-do-penetration-tests.html">How to do penetration testing</a></li>
   <li><a href="/standards/performance-testing.html">Performance testing</a></li>
-  <li><a href="/standards/sending-email.html">How to send email notifications</a></li>
+  <li><a href="/standards/sending-email.html">How to send email notifications to users</a></li>
   <li><a href="/standards/user-support.html">How MHCLG provides user support</a></li>
   <li><a href="/standards/incident-management.html">Incident management</a></li>
   <li><a href="/standards/disaster-recovery.html">Disaster Recovery</a></li>

--- a/source/standards/sending-email.html.md.erb
+++ b/source/standards/sending-email.html.md.erb
@@ -1,27 +1,13 @@
 ---
-title: How to send email notifications
-last_reviewed_on: 2000-01-01
+title: How to send email notifications to users
+last_reviewed_on: 2025-07-28
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
-
-At MHCLG you should use the following standards for sending email notifications to service users and engineers.
-
-## How to send notifications to users
 
 Use [GOV.UK Notify](https://www.notifications.service.gov.uk/) when sending notifications to users from a MHCLG service, for example password resets and confirmation emails.
 
 There's a [complete feature list](https://www.notifications.service.gov.uk/features) available of what you can do with GOV.UK Notify, and you can also register for [a Notify account](https://www.notifications.service.gov.uk/register) here.
 
 The Service Manual has further information related to [sending emails from your service domain](https://www.gov.uk/service-manual/technology/how-to-email-your-users).
-
-## How to send notifications to engineers
-
-Use an [alerting], [monitoring] or [logging] tool when you need to send automatic notifications from systems like [Cron](https://en.wikipedia.org/wiki/Cron) or [Jenkins](https://www.jenkins.io/) to engineers.
-
-To reduce inbox noise which can result in emails being ignored or overlooked, you should only use automatic email notifications from systems when the issue can’t be picked up through monitoring or logging. In these situations send email using [Amazon Simple Email Service (Amazon SES)](https://aws.amazon.com/ses/).
-
-[alerting]: alerting.html
-[monitoring]: monitoring.html
-[logging]: logging.html


### PR DESCRIPTION
Remove references to emailing engineers - this is covered in the logging/monitoring/alerting section, so was redundant.