### PR TITLE
Put Google SRE paradigm pages into own subsection with introductory overview

### DIFF
--- a/source/partials/_nav-logging-monitoring-alerting.html.erb
+++ b/source/partials/_nav-logging-monitoring-alerting.html.erb
@@ -2,6 +2,8 @@
   <li><a href="/standards/logging.html">Store and query logs</a></li>
   <li><a href="/standards/monitoring.html">How to monitor your service</a></li>
   <li><a href="/standards/alerting.html">How to manage alerts</a></li>
-  <li><a href="/standards/slo.html">Make data-driven decisions with Service Level Objectives (SLOs)</a></li>
-  <li><a href="/standards/slis.html">Run a Service Level Indicator (SLI) workshop</a></li>
+  <li>
+    <a href="/standards/sre/overview.html">Following the Google SRE playbook</a>
+    <%= partial '/partials/_nav-sre' %>
+  </li>
 </ul>

--- a/source/partials/_nav-sre.html.erb
+++ b/source/partials/_nav-sre.html.erb
@@ -1,0 +1,4 @@
+<ul>
+  <li><a href="/standards/sre/slo.html">Make data-driven decisions with Service Level Objectives (SLOs)</a></li>
+  <li><a href="/standards/sre/slis.html">Run a Service Level Indicator (SLI) workshop</a></li>
+</ul>

--- a/source/standards/sre/overview.html.md.erb
+++ b/source/standards/sre/overview.html.md.erb
@@ -1,0 +1,17 @@
+---
+title: Following the Google playbook for Site Reliability Engineering (SRE)
+last_reviewed_on: 2025-07-28
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+SRE as a paradigm, as practised within Google, offers a way of managing the inherent tension between a product team’s wish to achieve velocity in feature delivery, and what would traditionally be an operations team of sysadmins whose responsibility is to keep deployed environments stable.
+
+[Point 14 of the GOV.UK Service Standard][] codifies the responsibilities of a GOV.UK service team to provide a reliable service. The Google SRE paradigm, which includes the concepts of SLOs, SLIs, and error budgets, can be a useful one to adopt as it will assist in setting fine-grained service level expectations, and ensuring your team is able to deliver features and evolve your service while adhering to these agreed service levels.
+
+[Read an introduction](./slo.html) to setting Service Level Objectives (SLOs).
+
+Consider [running a Service Level Indicator (SLI) workshop](./slis.html).
+
+[Point 14 of the GOV.UK Service Standard]: https://www.gov.uk/service-manual/service-standard/point-14-operate-a-reliable-service 

--- a/source/standards/sre/slis.html.md.erb
+++ b/source/standards/sre/slis.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Run a Service Level Indicator (SLI) workshop
-last_reviewed_on: 2000-01-01
+last_reviewed_on: 2025-07-28
 review_in: 6 months
 ---
 

--- a/source/standards/sre/slo.html.md.erb
+++ b/source/standards/sre/slo.html.md.erb
@@ -1,10 +1,25 @@
 ---
 title: Make data-driven decisions with service level objectives
-last_reviewed_on: 2000-01-01
+last_reviewed_on: 2025-07-28
 review_in: 6 months
 ---
 
 # <%= current_page.data.title %>
+
+### Glossary of terms
+
+<dl>
+  <dt>SLI</dt>
+  <dd>Service level indicator - a carefully defined quantitative measure of some aspect of the level of service that is provided<dd>
+  <dt>SLO</dt>
+  <dd>Service level objective - a target value or range of values for a service level that is measured by an SLI<dd>
+  <dt>SLA</dt>
+  <dd>Service level agreement - an explicit or implicit contract with the users of your service<dd>
+</dl>
+
+For more detailed discussion of SLOs, SLIs, and SLAs, please consult [chapter 4 of the online Google SRE book](https://sre.google/sre-book/service-level-objectives/).
+
+## Service level objectives (SLOs)
 
 Service level objectives (SLOs) set out a target level for your service’s reliability. Using SLOs helps you make data-driven decisions about the [opportunity cost](https://www.investopedia.com/terms/o/opportunitycost.asp) of reliability work.
 


### PR DESCRIPTION
Moving pages on SLOs and SLIs into their own subsection, with a simple glossary and an introductory overview to reflect that, while no current MHCLG teams currently follow this paradigm in managing the balance between velocity of software delivery and maintaining reliability of deployed services, it's something that we encourage as a department.

