### PR TITLE
Updated aws-vault repo link

### DIFF
--- a/source/manuals/working-with-aws-accounts.html.md.erb
+++ b/source/manuals/working-with-aws-accounts.html.md.erb
@@ -20,11 +20,11 @@ There are several command line tools you can use to work with AWS, such as:
 * [AWS Shell](https://github.com/awslabs/aws-shell) - an integrated shell for working with the AWS CLI
 * [Terraform](https://www.terraform.io/) - for building, changing, and versioning infrastructure
 
-These tools need credentials to access AWS. We recommend using [aws-vault](https://github.com/99designs/aws-vault#readme) to manage your credentials.
+These tools need credentials to access AWS. We recommend using [aws-vault][] to manage your credentials.
 
 #### Installing aws-vault
 
-[aws-vault](https://github.com/99designs/aws-vault#readme) needs to be installed and available on your `PATH`. The
+[aws-vault][] needs to be installed and available on your `PATH`. The
 easiest way to do this is via Homebrew: `brew install --cask aws-vault`.
 
 #### Using aws-vault  
@@ -39,3 +39,4 @@ aws-vault exec developer -- aws s3 ls
 ```
 
 [Amazon Web Services (AWS)]: https://aws.amazon.com/
+[aws-vault]: https://github.com/ByteNess/aws-vault#readme


### PR DESCRIPTION
As suggested https://github.com/communitiesuk/mhclg-way/issues/78, amended aws-vault repo link in the "Working with AWS accounts" page