### PR TITLE
Update guidance about GitHub membership and collaborator requests

### DIFF
--- a/source/standards/source-code/use-github.html.md.erb
+++ b/source/standards/source-code/use-github.html.md.erb
@@ -8,7 +8,9 @@ review_in: 12 months
 
 MHCLG uses the [communitiesuk] organisation on [GitHub] to collaborate on code.
 
-## Getting access to `communitiesuk`
+## Getting access to ‘communitiesuk’
+
+### Membership of the ‘communitiesuk’ organisation
 
 You can use your personal GitHub account to access communitiesuk if you wish - [GitHub recommends using one personal
 account](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/managing-multiple-accounts)
@@ -23,8 +25,34 @@ You must also set up two-factor authentication on your account.
 
 To join `communitiesuk` first get approval from your delivery manager, tech lead or technical architect that this is required for your role.
 
-Next, either message `#help-github-admin` on Slack or email [GitHub.Admins@communities.gov.uk](mailto:GitHub.Admins@Communities.gov.uk) and an admin will action your request. Make sure you’ve [verified your MHCLG
-email address in your GitHub account](https://docs.github.com/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account) first, otherwise your account will be removed.
+Next, ask the GitHub admin team to add you - you can either send a message in the `#help-github-admin` channel on Slack,
+or email [GitHub.Admins@communities.gov.uk](mailto:GitHub.Admins@Communities.gov.uk) with the following information:
+
+* Your GitHub username
+* The team/project you are working on
+* The name of the tech lead/manager who has approved your access
+* Confirmation that you have set your name and communities.gov.uk email address on your GitHub user profile
+
+Make sure you’ve [verified your MHCLG email address in your GitHub account](https://docs.github.com/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account)
+first, otherwise your account will be removed.
+
+### Inviting “outside collaborators” to GitHub
+
+Most users working in our GitHub should have full membership of the organisation, as this allows people to create their
+own repositories and to belong to GitHub teams. However, in cases where people from other organisations need limited
+access to just a few of our repositories then they can be added as “outside collaborators” instead. (For example,
+someone from another department who needs to review the contents of a private repository, or a private prototype that
+needs to be used by people in another department.)
+
+To request an outside collaborator on a repository in communitiesuk that you own, send a request to the GitHub admin
+team with:
+
+* The GitHub username(s) of the person/people you want to invite
+* The repository/repositories that they should be invited to
+* The permissions they should have on those repositories (i.e. read-only or write)
+* An estimate of how long the person will need access
+
+**NOTE:** it is the responsibility of repository owners to remove outside collaborators when they no longer need access.
 
 ## Managing repositories
 

--- a/source/standards/source-code/use-github.html.md.erb
+++ b/source/standards/source-code/use-github.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use GitHub
-last_reviewed_on: 2025-03-04
+last_reviewed_on: 2026-04-22
 review_in: 12 months
 ---
 


### PR DESCRIPTION
We've recently had some confusuion about whether outside collaborators can be added to repositories - this adds some proposed guidance and process for requesting outside collaborators.

I have also added a bit more detail about what peoople should include in requests to join the org.